### PR TITLE
use public API to sync users and groups

### DIFF
--- a/src/main/node/handler.spec.ts
+++ b/src/main/node/handler.spec.ts
@@ -38,7 +38,7 @@ describe('handler', () => {
 
     // test user
     const testuser: User = new User();
-    testuser.userName = 'testuser';
+    testuser.id = 'testuser';
     testuser.firstName = 'First';
     testuser.lastName = 'Last';
     testuser.email = 'testuser@demo.com';
@@ -91,8 +91,8 @@ describe('handler', () => {
         });
 
         it('should return 422 when userId not found in users or groups', async () => {
-            when(pwsMock.getUser(testuser.userName)).thenReturn(Promise.resolve(null));
-            when(gwsMock.getGroups(testuser.userName)).thenReturn(Promise.resolve([]));
+            when(pwsMock.getUser(testuser.id)).thenReturn(Promise.resolve(null));
+            when(gwsMock.getGroups(testuser.id)).thenReturn(Promise.resolve([]));
 
             await handler.syncUser(gateWayEvent2, null, (x, response) => {
                 expect(response.statusCode).to.equal(422);
@@ -100,8 +100,8 @@ describe('handler', () => {
             });
         });
         it('should return 200 OK', async () => {
-            when(pwsMock.getUser(testuser.userName)).thenReturn(Promise.resolve(testuser));
-            when(gwsMock.getGroups(testuser.userName)).thenReturn(Promise.resolve(testgroups));
+            when(pwsMock.getUser(testuser.id)).thenReturn(Promise.resolve(testuser));
+            when(gwsMock.getGroups(testuser.id)).thenReturn(Promise.resolve(testgroups));
 
             await handler.syncUser(gateWayEvent2, null, (x, response) => {
                 expect(response.statusCode).to.equal(200);

--- a/src/main/node/handler.ts
+++ b/src/main/node/handler.ts
@@ -89,7 +89,7 @@ async function syncOneUser(username) {
     // handle shared netid
     if (!user && (groups && groups.length > 0)) {
         user = new User();
-        user.userName = username;
+        user.id = username;
         user.firstName = username;
         user.lastName = username;
         user.email = username + emailDomain;
@@ -98,7 +98,12 @@ async function syncOneUser(username) {
     if (!user) {
         throw new Error("Unable to identify User or Groups synchronization.");
     }
+
     // call acs to create new user
+    // password is required by Alfresco public API
+    // generate a random string of at least 8 characters
+    const randomInt = Math.floor(100000000000*Math.random()) + 1000000000;
+    user.password = randomInt.toString(36); // convert to base 36 to have letters and digits in string
     await acs.createUser(user);
 
     // add user to groups

--- a/src/main/node/model/user.ts
+++ b/src/main/node/model/user.ts
@@ -2,11 +2,9 @@ export class User {
     constructor() {
     }
 
-    userName: string;
+    id: string;
     firstName: string;
     lastName: string;
     email: string;
     password: string;
-    authorizationStatus= 'AUTHORIZED'
-
 }

--- a/src/main/node/services/acs.ts
+++ b/src/main/node/services/acs.ts
@@ -10,7 +10,7 @@ export class ACS {
     private request: any;
     static readonly UW_ROOT_GROUP_ID = 'uw_groups';
     constructor(acsUrlBase:string, adminUser:string, adminPassword:string) {
-        this.acsUrlPrefix = acsUrlBase + '/alfresco/service/api';
+        this.acsUrlPrefix = acsUrlBase + '/alfresco/api/-default-/public/alfresco/versions/1';
         this.auth = {
             'user': adminUser,
             'pass': adminPassword
@@ -42,17 +42,17 @@ export class ACS {
             if ( err.statusCode == 409 ) {
                 // user already exists, noop
             } else {
-                this.logError(err, 'ERROR - createUser returned error for user ' + user.userName);
+                this.logError(err, 'ERROR - createUser returned error for user ' + user.id);
                 throw(err);
             }
         });
     }
 
     // get user 
-    async getUser(username: string, wantGroups:boolean=false): Promise<any>  {
+    async getUser(username: string): Promise<any>  {
         let retv: any = null;
         const options = {
-            url: this.acsUrlPrefix + '/people/' + username + (wantGroups ? '?groups=true' : ''),
+            url: this.acsUrlPrefix + '/people/' + username,
             auth: this.auth
         }
         await this.request.get(options, (err, response, body) => {
@@ -75,35 +75,55 @@ export class ACS {
 
     // get user groups 
     async getUserGroups(username: string): Promise<any>  {
-        const user:any = await this.getUser(username, true);
-        return (user && user.groups && user.groups);
+        let retv: any = null;
+        const options = {
+            url: this.acsUrlPrefix + '/people/' + username + '/groups?fields=id&maxItems=1000',
+            auth: this.auth
+        }
+        await this.request.get(options, (err, response, body) => {
+            retv = JSON.parse(body);
+            if ( retv && retv.status && retv.status.code && retv.status.code==HTTP_STATUS_CODE_FOR_NOT_FOUND ) {
+                retv = null;
+            }
+        })
+        .catch((err) => {
+            if ( err.statusCode && err.statusCode == HTTP_STATUS_CODE_FOR_NOT_FOUND) {
+                retv = null;
+            } else {
+                this.logError(err, 'ERROR - getUserGroups returned error for user ' + username)
+                throw(err);
+            }
+        });
+
+        return (retv && retv.list && retv.list.entries);
     }
 
     // get members of a group 
     async getMembers(groupId: string): Promise<any>  {
-        let retv: string[] = [];
+        const gid = groupId.startsWith('GROUP_') ? groupId : 'GROUP_' + groupId;
+        let retv: any = [];
         const options = {
-            url: this.acsUrlPrefix + '/groups/' + groupId+ '/children?authorityType=USER',
+            url: this.acsUrlPrefix + '/groups/' + gid+ "/members?where=(memberType='PERSON')",
             auth: this.auth
         }
         await this.request.get(options, (err, response, body) => {
-            retv = JSON.parse(body).data;
+            retv = JSON.parse(body);
         })
         .catch((err) => {
-                this.logError(err, 'ERROR 2 - getMembers returned error for group ' + groupId)
-                throw(err);
+            this.logError(err, 'ERROR 2 - getMembers returned error for group ' + groupId)
+            throw(err);
         });
 
-        return retv;
+        return (retv && retv.list && retv.list.entries);
     }
 
     // displayName is null for a person, but may be set for a group member.
-    async addMember(groupId:string, memberId:string, displayName:string = ''): Promise<void> {
-        const gid = groupId.startsWith('GROUP_') ? groupId.substring('GROUP_'.length) : groupId;
+    async addMember(groupId:string, memberId:string, displayName:string = '', memberType='PERSON'): Promise<void> {
+        const gid = groupId.startsWith('GROUP_') ? groupId : 'GROUP_' + groupId;
         console.log('INFO - add ' + memberId + ' to group ' + groupId);
-        let body = displayName ? { displayName: displayName } : {};
+        let body = { id: memberId, displayName: displayName, memberType: memberType };
         const options = {
-            url: this.acsUrlPrefix + '/groups/' + gid + '/children/' + memberId,
+            url: this.acsUrlPrefix + '/groups/' + gid + '/members',
             auth: this.auth
         }
         await this.request.post(options).json(body)
@@ -120,10 +140,10 @@ export class ACS {
     }
 
     async deleteMember(groupId:string, memberId:string): Promise<void> {
-        const gid = groupId.startsWith('GROUP_') ? groupId.substring('GROUP_'.length) : groupId;
+        const gid = groupId.startsWith('GROUP_') ? groupId : 'GROUP_' + groupId;
         console.log('INFO - delete ' + memberId + ' from group ' + gid);
         const options = {
-            url: this.acsUrlPrefix + '/groups/' + gid + '/children/' + memberId,
+            url: this.acsUrlPrefix + '/groups/' + gid + '/members/' + memberId,
             auth: this.auth
         }
         await this.request.delete(options)
@@ -144,7 +164,7 @@ export class ACS {
         // find diff of the two groups
         const gmap = new Map<string, string>();
         existingGroups.forEach((g) => {
-            gmap.set(g.itemName, '');  // empty displayName indicates existing group
+            gmap.set(g.entry.id, '');  // empty group ID indicates existing group
         });
 
         groups.forEach((g) => {
@@ -161,7 +181,7 @@ export class ACS {
                 await this.addMember(key, userName)
                 .catch(async (err)=>{
                     if ( err.statusCode == HTTP_STATUS_CODE_FOR_NOT_FOUND) { // group does not exist, need to create it first
-                        await this.addMember(ACS.UW_ROOT_GROUP_ID, key, value)
+                        await this.addMember(ACS.UW_ROOT_GROUP_ID, key, value, 'GROUP')
                         .then(() => { this.addMember(key, userName, value);}); // try again
                     } else {  // unknown error
                         this.logError(err, 'ERROR - addMember(' + key + ',' + userName + ') returned error: ')
@@ -187,7 +207,7 @@ export class ACS {
         // find diff of the two member list 
         const mmap = new Map<string, string>();
         acsMembers && acsMembers.forEach((m) => {
-            mmap.set(m.shortName, 'acs');  // user in acs group
+            mmap.set(m.entry.id, 'acs');  // user in acs group
         });
 
         gwsMembers.forEach((m) => {

--- a/src/main/node/services/acs.ts
+++ b/src/main/node/services/acs.ts
@@ -110,7 +110,7 @@ export class ACS {
             retv = JSON.parse(body);
         })
         .catch((err) => {
-            this.logError(err, 'ERROR 2 - getMembers returned error for group ' + groupId)
+            this.logError(err, 'ERROR - getMembers returned error for group ' + groupId)
             throw(err);
         });
 

--- a/src/main/node/services/pws.spec.ts
+++ b/src/main/node/services/pws.spec.ts
@@ -18,7 +18,7 @@ describe('PWS', () => {
     describe('parseUser function', () => {
         it('should resolve with the input username', async () => {
             const user: User = await service.parseUser(userStr);
-            expect(user.userName).to.equal('tusername');
+            expect(user.id).to.equal('tusername');
             expect(user.firstName).to.equal('Tfirst');
             expect(user.lastName).to.equal('Tlast');
         });

--- a/src/main/node/services/pws.ts
+++ b/src/main/node/services/pws.ts
@@ -20,7 +20,7 @@ export class PWS {
     parseUser(userStr: string): User {
         let obj = JSON.parse(userStr);
         let user = new User();
-        user.userName = obj.UWNetID;
+        user.id = obj.UWNetID;
         user.firstName = obj.RegisteredFirstMiddleName;
         user.lastName = obj.RegisteredSurname;
         user.email = obj.UWNetID + '@uw.edu';


### PR DESCRIPTION
There were a few changes to data structure (user.id instead user.userName, for example) and url path from the service API to public API.

The changes were tested by recreating my account and by sync'ing test users.